### PR TITLE
Source org from cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you set the `Is the key READ only` to `false`, it will make the key with `rea
 ### Output
 
 ```bash
-gh migrate-deploy-keys --destination-organization lukastestorg2 --destination-token <REDACTED> --source-organization lukastestorg1 --source-token <REDACTED>
+gh migrate-deploy-keys --destination-org lukastestorg2 --destination-token <REDACTED> --source-org lukastestorg1 --source-token <REDACTED>
 
 ######################################################
 ######################################################

--- a/gh-migrate-deploy-keys
+++ b/gh-migrate-deploy-keys
@@ -956,7 +956,7 @@ ReadInputFile() {
     # Split the line into the org and repo name #
     #############################################
     ORG_REPO_NAME=$(echo "${LINE}" | tr '[:upper:]' '[:lower:]')
-    ORG_NAME=$(echo "${ORG_REPO_NAME}" | cut -d'/' -f1)
+    ORG_NAME=$SOURCE_ORG_NAME
     REPO_NAME=$(echo "${ORG_REPO_NAME}" | cut -d'/' -f2)
     READ_ONLY=$(echo "${LINE}" | cut -d',' -f2)
 


### PR DESCRIPTION
This changes uses the source-org passed in with the command line arg `--source-org`, ignoring the source org parsed from the input file.