### PR TITLE
fix REPO_NAME contains the READ_ONLY bit

### DIFF
--- a/gh-migrate-deploy-keys
+++ b/gh-migrate-deploy-keys
@@ -957,7 +957,7 @@ ReadInputFile() {
     #############################################
     ORG_REPO_NAME=$(echo "${LINE}" | tr '[:upper:]' '[:lower:]')
     ORG_NAME=$(echo "${ORG_REPO_NAME}" | cut -d'/' -f1)
-    REPO_NAME=$(echo "${ORG_REPO_NAME}" | cut -d'/' -f2)
+    REPO_NAME=$(echo "${ORG_REPO_NAME}" | cut -d'/' -f2 | cut -d',' -f1)
     READ_ONLY=$(echo "${LINE}" | cut -d',' -f2)
 
     # If READ_ONLY is not set, set it to true

--- a/gh-migrate-deploy-keys
+++ b/gh-migrate-deploy-keys
@@ -956,7 +956,7 @@ ReadInputFile() {
     # Split the line into the org and repo name #
     #############################################
     ORG_REPO_NAME=$(echo "${LINE}" | tr '[:upper:]' '[:lower:]')
-    ORG_NAME=$(echo "${ORG_REPO_NAME}" | cut -d'/' -f1)
+    ORG_NAME=$SOURCE_ORG_NAME
     REPO_NAME=$(echo "${ORG_REPO_NAME}" | cut -d'/' -f2 | cut -d',' -f1)
     READ_ONLY=$(echo "${LINE}" | cut -d',' -f2)
 


### PR DESCRIPTION
@admiralAwkbar @bryantson the trailing part of REPO_NAME contains the READ_ONLY bit as well and needs to be chopped out with colon delim.

```
Org_Name/Repo_Name1,true
Org_Name/Repo_Name2,false
Org_Name/Repo_Name3
```